### PR TITLE
fix title anchor text is outside of element 'a'

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -73,7 +73,7 @@ Renderer.prototype.heading = function(text, level) {
   }
 
   // add headerlink
-  return '<h' + level + ' id="' + id + '"><a href="#' + id + '" class="headerlink" title="' + innerText + '"></a>' + innerHTML + '</h' + level + '>';
+  return '<h' + level + ' id="' + id + '"><a href="#' + id + '" class="headerlink" title="' + innerText + '">' + innerHTML + '</a></h' + level + '>';
 };
 
 function anchorId(str, transformOption) {


### PR DESCRIPTION
example
``` markdown
# title
```

before
``` html
<h1 id="title">
  <a href="#title" class="headerlink" title="title"></a>
  title
</h1>
```

after
``` html
<h1 id="title">
  <a href="#title" class="headerlink" title="title">title</a>
</h1>
```